### PR TITLE
update broken links in getting-started-

### DIFF
--- a/getting-started-participants.md
+++ b/getting-started-participants.md
@@ -1,6 +1,6 @@
 # I want to participate, where do I start?
 
-So you know what [we are about](https://github.com/djangonaut-space/pilot-program/blob/main/README.md), you have read our [code of conduct](https://github.com/djangonaut-space/pilot-program/blob/main/CODE_OF_CONDUCT.md), and you are interested in getting started, so what now?
+So you know what [we are about](README.md), you have read our [Code of Conduct](CODE_OF_CONDUCT.md), and you are interested in getting started, so what now?
 
 Because we are an inclusive community with a large range of skill levels we want to make sure we all have some understanding of a few points: Django, Python, Open Source Contributing, and Git. You aren't expected to be an expert in any of these but some knowledge will definitely help get you started. Please read the through the questions below to find a question that you can relate with to help you find your starting point. 
 
@@ -16,10 +16,10 @@ Because we are an inclusive community with a large range of skill levels we want
 - Django also has a [contributing tutorial](https://docs.djangoproject.com/en/dev/internals/contributing/). Going through this will make sure you're set up to tackle tickets.
 
 **What are the expectations of participants?**
-- Have good standing throughout the program and uphold the [code of conduct](https://github.com/djangonaut-space/pilot-program/blob/main/CODE_OF_CONDUCT.md).
+- Have good standing throughout the program and uphold the [Code of Conduct](CODE_OF_CONDUCT.md).
 - Attend weekly meetings to receive feedback and support.
 - A commitment of 4 hours a week over the course of 8-weeks.
-- For more details about being a participant, please read our [Djangonaut Guidelines](https://github.com/djangonaut-space/pilot-program/blob/main/djangonauts.md).
+- For more details about being a participant, please read our [Djangonaut Guidelines](djangonauts.md).
 
 **I want to join, how do I sign up?**
 Check out our website for the latest information: [djangonaut.space](https://djangonaut.space)

--- a/getting-started-volunteer.md
+++ b/getting-started-volunteer.md
@@ -1,21 +1,21 @@
 # I want to volunteer, where do I start?
 
-So you know what [we are about](https://github.com/djangonaut-space/pilot-program/blob/main/README.md), you have read our [code of conduct](https://github.com/djangonaut-space/pilot-program/blob/main/CODE_OF_CONDUCT.md), and you are interested in volunteering, so what now? First of all, thank you! Our community thrives because of people like you.
+So you know what [we are about](README.md), you have read our [Code of Conduct](CODE_OF_CONDUCT.md), and you are interested in volunteering, so what now? First of all, thank you! Our community thrives because of people like you.
 
 ## Types of Volunteers
-There are a few ways to volunteer with this community: as a [Navigator](https://github.com/djangonaut-space/pilot-program/blob/main/navigators.md), [Captain](https://github.com/djangonaut-space/pilot-program/blob/main/captains.md), or Organizer. We have summarized those roles here as an overview but please read their detailed guidelines to get a more in-depth understanding of each. 
+There are a few ways to volunteer with this community: as a [Navigator](navigators.md), [Captain](captains.md), or Organizer. We have summarized those roles here as an overview but please read their detailed guidelines to get a more in-depth understanding of each.
 
 **Navigator:**
 - Navigators can expect to commit 2 hours of their time each week over the 8-week session. 
 - This would involve showing up to our virtual meetings/co-working hours and assisting other members or helping out members in the discord channel. 
-- More details: [Navigator Guideline](https://github.com/djangonaut-space/pilot-program/blob/main/navigators.md)
+- More details: [Navigator Guideline](navigators.md)
 
 
 **Captain:**
 - Attend welcome and closing sessions and be available on discord.
 - Check-in with Navigators and Djangonauts regularly throughout the program. 
 - Commit 2 hours a week for 8-weeks. 
-- More details: [Captain Guidelines](https://github.com/djangonaut-space/pilot-program/blob/main/captains.md)
+- More details: [Captain Guidelines](captains.md)
 
 **Organizer:**
 - Responsible for organizing and leading meetings, update statuses on our website and GitHub, organization communication, Code of Conduct follow through, and recruiting volunteers.


### PR DESCRIPTION
Links to various markdown files in this repositoy still point to the old repository. Updated using `djangonauts.md` style as example.