### PR TITLE
Add document outlining the governance for Djangonaut Space

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,77 @@
+# Djangonaut Space Governance
+
+This document outlines the formal governance of the Djangonaut Space organization.
+
+## Roles
+This section identifies the roles of the organization.
+
+### Admin
+All admins are of equal status. Each admin’s vote counts the same as another’s. An admin can call a meeting with other admins at their discretion.
+
+An admin can be removed from the team via a formal decision in [Decision Making](#decision-making).
+
+#### Expected contributions
+Admins should be on the server and engaged. They should be responsive via email or via their Discord mentions of the @admins tag. They should attend most of admin meetings. They should be supportive of session admins while session admins are active.
+
+These numbers exist to provide a minimum baseline. They are meant to be easily achievable and should not be target levels of interaction. They can be used to remove an inactive admin though.
+
+- One productive conversation with a non-admin and non-advisor on the Discord per month
+- A reaction or message response to 50% of `@admins` tag mentions by session admins
+- Attendance of 50% of meetings with admins
+- Attend one session admin meeting per session
+- Be assigned one action item every two admin admin meetings
+
+#### Role size
+The admin role should strive to be staffed by three to five people. There are no hard limits if the team wants to run smaller or larger for periods of time.
+
+#### Adding Admins
+Admins are invited by admins where there is a 50% approval to invite a person. Advisors can suggest and/or recommend additional admins.
+
+#### Term limits
+An admin is welcome on the team for as long as they’d like. They need to confirm their desire to be a part of the team every 12 months.
+
+### Advisor
+Advisors are intended to be a group of people who can provide feedback, advice and opinions. They should be connected with the broader Django, Python and open source communities. 
+
+Advisors are not able to vote on measures or decisions. They can call for a meeting with admins, but do not need regular meetings.
+
+#### Expected contributions
+Advisors should be on the server and sporadically interactive. They should be responsive via email or via their Discord mentions of the `@advisors` tag. They should attend most of the meetings that are arranged with admins.
+
+These numbers exist to provide a minimum baseline. They are meant to be easily achievable and should not be target levels of interaction. They can be used to remove an inactive advisor though.
+
+- One productive conversation with a non-admin on the Discord per quarter
+- A reaction or message response to 50% of `@advisors` tag mentions by advisors
+- Attendance of 50% of meetings with admins. If there are more than 6 of said meetings, advisors only need to attend 3 total for the year.
+
+#### Role size
+There can be zero to nine advisors.
+
+#### Adding Advisors
+Advisors are invited by admins where there is a 50% approval to invite a person. Existing advisors can suggest and/or recommend additional advisors.
+
+#### Term limits
+An advisor can be on the team for up to three consecutive years. They need to confirm their desire to be a part of the team every 12 months.
+
+## Processes
+This section identifies the defined processes of the Djangonaut Space organizing team.
+
+### Decision making
+A formal decision, such as approving this document or making a change to it, requires approval of more than 50% of admins. The decision should be added to the Decision Record document.
+
+Before voting on a structural decision, it must be announced at least three days before the meeting and must be done in a way that actively notifies all other admins.
+
+### Annual Reports
+Every year the admins should put together an annual report. It must account for the following:
+
+- Session participation metrics
+- Financial report
+    - Donations per source
+    - Tools
+    - Financial aid
+    - [Open Collective](https://opencollective.com/djangonaut-space) / fiscal fees
+    - Marketing
+- Goals for the next year
+
+### Code of Conduct Reporting
+Code of Conduct violations have two routes. For reports with Djangonauts, Captains, Navigators please refer to the [program documentation](https://github.com/djangonaut-space/program/blob/main/CODE_OF_CONDUCT.md). If the violation involves a fellow admin, you can email CoC@djangonaut.space If you’re uncomfortable with that route, please report the violation following [Django’s Code of Conduct reporting guidelines](https://www.djangoproject.com/conduct/reporting/).


### PR DESCRIPTION
This reflects the decision on 2025-05-22 by the admins to adopt the new governance.